### PR TITLE
Remove inline from method

### DIFF
--- a/src/data/Scenario.cpp
+++ b/src/data/Scenario.cpp
@@ -343,7 +343,7 @@ void Scenario::updateNewWeek(PDemand pDemand, PPreferences pPreferences, vector<
 	thisWeek_++;
 }
 
-inline void Scenario::linkWithPreferences(PPreferences pPreferences) {
+void Scenario::linkWithPreferences(PPreferences pPreferences) {
   pWeekPreferences_ = pPreferences;
   nbShiftOffRequests_ = 0;
   for (PNurse nurse:theNurses_) {


### PR DESCRIPTION
This inline breaks the linking step, and isn’t needed anyway.