### PR TITLE
Comment out b_is_valid

### DIFF
--- a/src/solvers/mp/rcspp/RCGraph.cpp
+++ b/src/solvers/mp/rcspp/RCGraph.cpp
@@ -789,7 +789,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
   while( !unprocessed_labels.empty()  && vis.on_enter_loop(unprocessed_labels, g) )
   {
     Splabel cur_label = unprocessed_labels.top();
-    assert (cur_label->b_is_valid);
+    //assert (cur_label->b_is_valid);
     unprocessed_labels.pop();
     vis.on_label_popped( *cur_label, g );
     // an Splabel object in unprocessed_labels and the respective Splabel
@@ -804,7 +804,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
     // if there is a chance that extending the
     // label leads to new undominated labels, which in turn is possible only
     // if the label to be extended is undominated
-    assert (cur_label->b_is_valid);
+    //assert (cur_label->b_is_valid);
     if( !cur_label->b_is_dominated )
     {
       typename boost::graph_traits<Graph>::vertex_descriptor
@@ -821,7 +821,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
         while( outer_iter != list_labels_cur_vertex.end() )
         {
           Splabel cur_outer_splabel = *outer_iter;
-          assert (cur_outer_splabel->b_is_valid);
+          //assert (cur_outer_splabel->b_is_valid);
           typename std::list<Splabel>::iterator inner_iter = outer_iter;
           if( !b_outer_iter_at_or_beyond_last_valid_pos_for_dominance
               && outer_iter ==
@@ -844,7 +844,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
           while( inner_iter != list_labels_cur_vertex.end() )
           {
             Splabel cur_inner_splabel = *inner_iter;
-            assert (cur_inner_splabel->b_is_valid);
+            //assert (cur_inner_splabel->b_is_valid);
             if( dominance( cur_outer_splabel->
                                cumulated_resource_consumption,
                            cur_inner_splabel->
@@ -855,7 +855,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
               list_labels_cur_vertex.erase( buf );
               if( cur_inner_splabel->b_is_processed )
               {
-                cur_inner_splabel->b_is_valid = false;
+                //cur_inner_splabel->b_is_valid = false;
                 l_alloc.destroy( cur_inner_splabel.get() );
                 l_alloc.deallocate( cur_inner_splabel.get(), 1 );
                 nbDeletedLabels++;
@@ -875,7 +875,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
               ++outer_iter;
               list_labels_cur_vertex.erase( buf );
               b_outer_iter_erased = true;
-              assert (cur_outer_splabel->b_is_valid);
+              //assert (cur_outer_splabel->b_is_valid);
               if( cur_outer_splabel->b_is_processed )
               {
                 label_trash.push_back(cur_outer_splabel);
@@ -906,7 +906,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
             list_labels_cur_vertex.size() - 1);
       }
     }
-    assert (b_all_pareto_optimal_solutions || cur_label->b_is_valid);
+    assert (b_all_pareto_optimal_solutions/* || cur_label->b_is_valid*/);
 
     // ------------------------------------------------------------------------- START SAMUEL
     //if( !b_all_pareto_optimal_solutions && cur_label->resident_vertex == t )
@@ -917,7 +917,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
       // the devil don't sleep
       if( cur_label->b_is_dominated )
       {
-        cur_label->b_is_valid = false;
+        //cur_label->b_is_valid = false;
         l_alloc.destroy( cur_label.get() );
         l_alloc.deallocate( cur_label.get(), 1 );
         nbDeletedLabels++;
@@ -925,13 +925,13 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
       while( unprocessed_labels.size() )
       {
         Splabel l = unprocessed_labels.top();
-        assert (l->b_is_valid);
+        //assert (l->b_is_valid);
         unprocessed_labels.pop();
         // delete only dominated labels, because nondominated labels are
         // deleted at the end of the function
         if( l->b_is_dominated )
         {
-          l->b_is_valid = false;
+          //l->b_is_valid = false;
           l_alloc.destroy( l.get() );
           l_alloc.deallocate( l.get(), 1 );
           nbDeletedLabels++;
@@ -953,6 +953,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
         b_feasible = true;
         boost::r_c_shortest_paths_label<Graph, Resource_Container>* new_label =
             l_alloc.allocate( 1 );
+        /*
         l_alloc.construct( new_label,
                            boost::r_c_shortest_paths_label
                                <Graph, Resource_Container>
@@ -961,6 +962,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
                                  cur_label.get(),
                                  *oei,
                                  target( *oei, g ) ) );
+        */
         nbCreatedLabels++;
 
         b_feasible =
@@ -972,7 +974,7 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
         if( !b_feasible )
         {
           vis.on_label_not_feasible( *new_label, g );
-          new_label->b_is_valid = false;
+          //new_label->b_is_valid = false;
           l_alloc.destroy( new_label );
           l_alloc.deallocate( new_label, 1 );
           nbDeletedLabels++;
@@ -991,9 +993,9 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
     }
     else
     {
-      assert (cur_label->b_is_valid);
+      //assert (cur_label->b_is_valid);
       vis.on_label_dominated( *cur_label, g );
-      cur_label->b_is_valid = false;
+      //cur_label->b_is_valid = false;
       l_alloc.destroy( cur_label.get() );
       l_alloc.deallocate( cur_label.get(), 1 );
       nbDeletedLabels++;
@@ -1016,14 +1018,14 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
             cur_pareto_optimal_path;
         const boost::r_c_shortest_paths_label<Graph, Resource_Container>* p_cur_label =
             (*csi).get();
-        assert (p_cur_label->b_is_valid);
+        //assert (p_cur_label->b_is_valid);
         pareto_optimal_resource_containers.
             push_back( p_cur_label->cumulated_resource_consumption );
         while( p_cur_label->num != 0 )
         {
           cur_pareto_optimal_path.push_back( p_cur_label->pred_edge );
-          p_cur_label = p_cur_label->p_pred_label;
-          assert (p_cur_label->b_is_valid);
+          p_cur_label = p_cur_label->p_pred_label.get();
+          //assert (p_cur_label->b_is_valid);
         }
         pareto_optimal_solutions.push_back( cur_pareto_optimal_path );
         if( !b_all_pareto_optimal_solutions )
@@ -1066,16 +1068,16 @@ void r_c_shortest_paths_dispatch_several_sinks( const Graph& g,
     csi_end = list_labels_cur_vertex.end();
     for( csi = list_labels_cur_vertex.begin(); csi != csi_end; ++csi )
     {
-      assert ((*csi)->b_is_valid);
-      (*csi)->b_is_valid = false;
+      //assert ((*csi)->b_is_valid);
+      //(*csi)->b_is_valid = false;
       l_alloc.destroy( (*csi).get() );
       l_alloc.deallocate( (*csi).get(), 1 );
       nbDeletedLabels++;
     }
   }
   for (Splabel label: label_trash) {
-    assert(label->b_is_valid );
-    label->b_is_valid = false;
+    //assert(label->b_is_valid );
+    //label->b_is_valid = false;
     l_alloc.destroy( label.get() );
     l_alloc.deallocate( label.get(), 1 );
   }


### PR DESCRIPTION
The only reference to this property I could find in boost is in a comment[0], but it prevents this file from compiling.  This seems to introduce a segfault afterwards, which I haven’t been able to fix yet.

[0] https://live.boost.org/doc/libs/master/boost/graph/r_c_shortest_paths.hpp