### PR TITLE
Fix: Username inconsitent with Dockerfile

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -15,15 +15,15 @@ Look at the docker-entrypoint.sh file for more details.
 3. The results are written in outfiles/n005w4_0_1-2-3-3/unixtimestamps (unixtimestamps is computed at every run). You should also link the container to different volumes to be able to:
   - Access the results:
   ```bash
-  docker run --rm -v "$(pwd)/outfiles:/home/poly/ns/outfiles" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
+  docker run --rm -v "$(pwd)/outfiles:/home/dantzig/ns/outfiles" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
   ```
   - Add some instances:
   ```bash
-  docker run --rm -v "$(pwd)/datasets:/home/poly/ns/datasets" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
+  docker run --rm -v "$(pwd)/datasets:/home/dantzig/ns/datasets" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
   ```
   - Add a configuration file:
   ```bash
-  docker run --rm -v "$(pwd)/paramfiles:/home/poly/ns/paramfiles" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
+  docker run --rm -v "$(pwd)/paramfiles:/home/dantzig/ns/paramfiles" legraina/nurse-scheduler -i n005w4_0_1-2-3-3
   ```
 
 


### PR DESCRIPTION
Username does not match the docker image. Consequentially, volumes mounted with `-v` does not match the expected path of the solver.